### PR TITLE
Adding migration for missing 'custom_import' column.

### DIFF
--- a/migrations/20240826134401-v3.3.1.js
+++ b/migrations/20240826134401-v3.3.1.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240826134401-v3.3.1-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20240826134401-v3.3.1-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20240826134401-v3.3.1-down.sql
+++ b/migrations/sqls/20240826134401-v3.3.1-down.sql
@@ -1,0 +1,6 @@
+/*
+Downgrading from version 3.0.0
+https://github.com/ptrumpis/snap-camera-server/releases/tag/v3.0.0
+*/
+ALTER TABLE `lenses` DROP COLUMN `custom_import`;
+ALTER TABLE `unlocks` DROP COLUMN `custom_import`;

--- a/migrations/sqls/20240826134401-v3.3.1-up.sql
+++ b/migrations/sqls/20240826134401-v3.3.1-up.sql
@@ -1,0 +1,6 @@
+/*
+Upgrading to version 3.0.0
+https://github.com/ptrumpis/snap-camera-server/releases/tag/v3.0.0
+*/
+ALTER TABLE `lenses` ADD COLUMN `custom_import` tinyint(1) unsigned NOT NULL DEFAULT 0;
+ALTER TABLE `unlocks` ADD COLUMN `custom_import` tinyint(1) unsigned NOT NULL DEFAULT 0;


### PR DESCRIPTION
Getting some errors when starting up the mysql server.

Error: Unknown column 'custom_import' in 'field list'
webapp-1    |     at Packet.asError (/usr/src/app/node_modules/mysql2/lib/packets/packet.js:738:17)
webapp-1    |     at Query.execute (/usr/src/app/node_modules/mysql2/lib/commands/command.js:29:26)
webapp-1    |     at PoolConnection.handlePacket (/usr/src/app/node_modules/mysql2/lib/connection.js:481:34)
webapp-1    |     at PacketParser.onPacket (/usr/src/app/node_modules/mysql2/lib/connection.js:97:12)
webapp-1    |     at PacketParser.executeStart (/usr/src/app/node_modules/mysql2/lib/packet_parser.js:75:16)
webapp-1    |     at Socket.<anonymous> (/usr/src/app/node_modules/mysql2/lib/connection.js:104:25)
webapp-1    |     at Socket.emit (node:events:513:28)
webapp-1    |     at addChunk (node:internal/streams/readable:315:12)
webapp-1    |     at readableAddChunk (node:internal/streams/readable:289:9)
webapp-1    |     at Socket.Readable.push (node:internal/streams/readable:228:10)
webapp-1    |     at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
webapp-1    |   code: 'ER_BAD_FIELD_ERROR',
webapp-1    |   errno: 1054,
webapp-1    |   sqlState: '42S22',
webapp-1    |   sqlMessage: "Unknown column 'custom_import' in 'field list'",
webapp-1    |   sql: "INSERT INTO lenses SET `unlockable_id` = '36899040876', `uuid` = '6ea585588cd04078ab59058dbf64580b', ... , `obfuscated_user_slug` = 'zNY45R4zBSahj3Iqg3u8aA', `image_sequence` = '{}', `web_import` = 0, `custom_import` = 0"

Added the migration files to create the column into the 'lenses' and 'unlocks' tables.
