### PR TITLE
Potential fix for code scanning alert no. 15: Type confusion through parameter tampering

### DIFF
--- a/src/endpoints/import/cache.js
+++ b/src/endpoints/import/cache.js
@@ -39,7 +39,7 @@ const formMiddleWare = (req, res, next) => {
             }
         }
 
-        req.files = allFiles;
+        req.files = Array.isArray(allFiles) ? allFiles : [allFiles];
         req.allowOverwrite = fields.allow_overwrite === 'true';
 
         next();


### PR DESCRIPTION
Potential fix for [https://github.com/ptrumpis/snap-camera-server/security/code-scanning/15](https://github.com/ptrumpis/snap-camera-server/security/code-scanning/15)

To fix the problem, we need to ensure that `req.files` is always an array before processing it. This can be done by checking the type of `req.files` and converting it to an array if it is not already one. This will prevent any type confusion and ensure that the code behaves as expected.

We will add a type check for `req.files` before processing it in the `formMiddleWare` function. If `req.files` is not an array, we will convert it to an array. This change will be made in the file `src/endpoints/import/cache.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
