### PR TITLE
Fix gencert

### DIFF
--- a/gencert.bat
+++ b/gencert.bat
@@ -1,23 +1,53 @@
 @echo off
+setlocal
+
+if not exist "ssl" mkdir "ssl"
+
 IF EXIST "ssl\studio-app.snapchat.com.key" (
 	IF EXIST "ssl\studio-app.snapchat.com.crt" (
 		echo SSL certificate already exists.
-		exit
+		exit /b 0
 	)
 )
-SET command=req -x509 -nodes -days 3650 -subj "/C=CA/ST=QC/O=Snap Inc./CN=studio-app.snapchat.com" -addext "subjectAltName=DNS:*.snapchat.com" -newkey rsa:2048 -keyout ./ssl/studio-app.snapchat.com.key -out ./ssl/studio-app.snapchat.com.crt
+
+REM create tmp cfg
+set "TEMP_CONF=%TEMP%\openssl_%RANDOM%.cnf"
+(
+echo [ req ]
+echo distinguished_name = req_distinguished_name
+echo prompt = no
+echo [ req_distinguished_name ]
+echo [ v3_ca ]
+echo subjectAltName = DNS:*.snapchat.com
+) > "%TEMP_CONF%"
+
+set COMMAND=req -x509 -nodes -days 3650 -subj "/C=CA/ST=QC/O=Snap Inc./CN=studio-app.snapchat.com" -newkey rsa:2048 -keyout .\ssl\studio-app.snapchat.com.key -out .\ssl\studio-app.snapchat.com.crt -config "%TEMP_CONF%"
+
 WHERE openssl >nul 2>&1
 IF %ERRORLEVEL% == 0 (
-	openssl %command%
+	openssl %COMMAND%
 ) ELSE (
 	IF EXIST "%programfiles%\OpenSSL-Win64\bin\openssl.exe" (
-		"%programfiles%\OpenSSL-Win64\bin\openssl.exe" %command%
+		"%programfiles%\OpenSSL-Win64\bin\openssl.exe" %COMMAND%
 	) ELSE (
 		IF EXIST "%programfiles(x86)%\OpenSSL-Win32\bin\openssl.exe" (
-			"%programfiles(x86)%\OpenSSL-Win32\bin\openssl.exe" %command%
+			"%programfiles(x86)%\OpenSSL-Win32\bin\openssl.exe" %COMMAND%
 		) ELSE (
 			echo Error: OpenSSL could not be found on your system. Please download and install OpenSSL.
+			del "%TEMP_CONF%" 2>nul
 			pause
+			exit /b 1
 		)
 	)
 )
+
+REM remove tmp cfg
+del "%TEMP_CONF%" 2>nul
+
+if exist "ssl\studio-app.snapchat.com.key" if exist "ssl\studio-app.snapchat.com.crt" (
+	echo SSL certificate generated successfully.
+) else (
+	echo Certificate generation failed.
+)
+
+endlocal


### PR DESCRIPTION
OpenSSL: Win64 OpenSSL v4.0.2
Error:
```
Error checking x509 extension section v3_ca
3C310000:error:11000078:X509 V3 routines:v2i_AUTHORITY_KEYID:unknown option:crypto\x509\v3_akid.c:123:name=keyid option=nonss
3C310000:error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension:crypto\x509\v3_conf.c:48:section=v3_ca, name=authorityKeyIdentifier, value=keyid:nonss,issuer:nonss
```

WA:
- Create tmp cfg with [req] and empty [v3_ca] sections
- Use this cfg for gen cmd
- Remove tmp cfg after failure or generation

_Verified only for Windows_